### PR TITLE
feat: Support providing both a context and an error object

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           command: npm run lint
       - run:
           name: Test
-          command: npm run test
+          command: npm run test:json
       - persist_to_workspace:
           root: ~/repo
           paths:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "lint": "eslint .",
     "semantic-release": "semantic-release",
-    "test": "mocha"
+    "test": "mocha",
+    "test:json": "mocha --reporter json"
   },
   "repository": {
     "type": "git",

--- a/src/jsonLogger.js
+++ b/src/jsonLogger.js
@@ -14,11 +14,14 @@ function formatError(data) {
 	return data;
 }
 
-function log(level, message, context = {}) {
+function log(level, message, context = {}, errorObject) {
 	let contextObject = context;
 
-	if (level === [ERROR]) {
-		contextObject = formatError(context);
+	if (level === ERROR) {
+		contextObject = {
+			...formatError(context),
+			...formatError(errorObject),
+		};
 	}
 
 	const payload = JSON.stringify({

--- a/src/simpleLogger.js
+++ b/src/simpleLogger.js
@@ -18,14 +18,15 @@ const formatting = {
 	},
 };
 
-function log(level, message, context = '') {
+function log(level, message, context = '', errorObject) {
 	const {color, colorAll} = formatting[level];
+	const contextObjects = [context, errorObject].filter(Boolean); // Ignore undefined context objects
 
 	if (colorAll) {
-		console.log(color(util.format(`${level}: ${message}`, context))); // eslint-disable-line no-console
+		console.log(color(util.format(`${level}: ${message}`, ...contextObjects))); // eslint-disable-line no-console
 	}
 	else {
-		console.log(`${color(`${level}:`)} ${message}`, context); // eslint-disable-line no-console
+		console.log(`${color(`${level}:`)} ${message}`, ...contextObjects); // eslint-disable-line no-console
 	}
 }
 

--- a/test/jsonLogger.spec.js
+++ b/test/jsonLogger.spec.js
@@ -32,7 +32,7 @@ describe('JSON logger', () => {
 		process.stdout.write = write;
 	});
 
-	it('should log 1-line json messages to the standard output', () => {
+	it('logs 1-line json messages to the standard output', () => {
 		const testMessage = 'simple message';
 
 		logger.info(testMessage);
@@ -43,5 +43,26 @@ describe('JSON logger', () => {
 			tag: TAG,
 			timestamp: now.toISOString(),
 		}));
+	});
+
+	it('provides the details of the error and its context ', () => {
+		const humanReadableErrorMessage = 'Unknown user';
+		const originalErrorMessage = 'user not found';
+		const error = new Error(originalErrorMessage);
+		error.statusCode = 404;
+		const context = {id: 1, host: 'example.com'};
+
+		logger.error(humanReadableErrorMessage, context, error);
+
+		sinon.assert.match(JSON.parse(output.trim()), {
+			level: 'error',
+			message: humanReadableErrorMessage,
+			tag: TAG,
+			timestamp: now.toISOString(),
+			...context,
+			error: originalErrorMessage,
+			statusCode: 404,
+			stacktrace: sinon.match.array,
+		});
 	});
 });

--- a/test/simpleLogger.spec.js
+++ b/test/simpleLogger.spec.js
@@ -23,7 +23,7 @@ describe('Simple logger', () => {
 		process.stdout.write = write;
 	});
 
-	it('should log messages to the standard output', () => {
+	it('logs messages to the standard output', () => {
 		const testMessage = 'simple message';
 
 		logger.info(testMessage);


### PR DESCRIPTION
This PR solves the problem where you need to manually create a context object from the error context
and the error object  before passing it to `logger.error`.

You can now provide both the error object and the context in which it happened to `logger.error`
and it will merge both objects automatically.

Example:
```js
const a = 1;
const b = 2;

try {
 doSomething(a, b);
}
catch (error)
  logger.error('Failed to process the data', {a, b}, error);
}
```