### PR TITLE
feat(stacktrace): Show entire stacktrace

### DIFF
--- a/src/jsonLogger.js
+++ b/src/jsonLogger.js
@@ -6,7 +6,7 @@ function formatError(data) {
 	if (data instanceof Error) {
 		return {
 			error: data.message,
-			stacktrace: data.stack ? data.stack.split('\n').slice(1, 3).map(line => line.trim()) : undefined,
+			stacktrace: data.stack ? data.stack.split('\n').map(line => line.trim()) : undefined,
 			statusCode: data.statusCode
 		};
 	}


### PR DESCRIPTION
**This PR**
- Change to show the entire stacktrace.


I find the current stack-trace, whilst simple, does not have enough information for debugging an issue. 

i.e. I do not know where this [Error](https://app.datadoghq.com/logs?query=status%3Aerror%20service%3Aapp&cols=host%2Cservice&event=AQAAAX7T6d4wmXsZDAAAAABBWDdUNmVzVkFBQ0Z6NzVjM0pXTFh3QUI&index=%2A&messageDisplay=inline&stream_sort=desc&from_ts=1641641106803&to_ts=1644233106803&live=false) was called 
```json
{
	"content": {
		"service": "app",
		"message": "themepark: could not load https://frontend-cdn.5app.com/public/themepark/production/style.json",
		"attributes": {
			"stacktrace": [
				"at Request.<anonymous> (/home/node/app/node_modules/got/dist/source/as-promise/index.js:117:42)",
				"at runMicrotasks (<anonymous>)"
			],
			"tag": "d5370b1",
			"error": "Response code 404 (Not Found)",
			"timestamp": "2022-02-07T11:20:26.416Z",
			"level": "error"
		}
	}
}
```

**For consideration:...**
We could filter out the lines with `node_modules` as debugging a third party is not as preferable to knowing where in our code we called that third party IMO.