### PR TITLE
feat: add slackAlert logger function

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,22 @@ logger.info('An event happened', {a: 1, b: Date.now(), c: 'some string'});
 logger.debug('A minor operation', {a: 1, b: Date.now(), c: 'some string'});
 ```
 
+## Slack alerts
+
+`logger.slackAlert([level], message, ...)` logs like the regular level functions above, but prepends `slackAlert ` to the message and adds a random `slackAlertId` (via [`crypto.randomUUID()`](https://nodejs.org/api/crypto.html#cryptorandomuuidoptions)) to the logged context, generating one even if no context is provided. `level` is optional and defaults to `'error'`; when provided it must be one of `'debug'`, `'info'`, `'warn'`, or `'error'`. Any remaining arguments are forwarded as-is to `logger.<level>`, so they follow that level's own signature (e.g. `context` and `errorObject` for `'error'`, just `context` for the others).
+
+This is intended for hooking up a log-shipping pipeline (e.g. a log processor that watches for the `slackAlert ` prefix) to post the message to Slack, using `slackAlertId` to correlate the Slack post back to the original log line, while still logging it at the given severity.
+
+```javascript
+logger.slackAlert('Payment provider is down', error); // level defaults to "error"
+logger.slackAlert('warn', 'Queue depth is high', {depth: 1200}); // context is merged with {slackAlertId: '...'}
+logger.slackAlert('warn', 'Queue depth is high'); // context defaults to {slackAlertId: '...'}
+logger.slackAlert('error', 'Payment provider is down', {provider: 'stripe'}, error);
+logger.slackAlert('error', 'Payment provider is down', error); // the (message, errorObject) shorthand also works; slackAlertId is added alongside the error details
+```
+
+Note: because `level` is detected by checking if the first argument is a known level string, passing an unrecognised level (e.g. a typo like `'eror'`) is not an error — it's silently read as `message` instead, with `level` defaulting to `'error'`.
+
 ## Fetching context dynamically
 
 In addition to providing a context object, you can also use `logger.addContext` to provide a function which will be called on every log to get a context object.

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ function slackAlert(levelOrMessage, ...rest) {
 	// `level` is optional and defaults to "error". If the first argument isn't a known level,
 	// treat it as `message` instead (so an unrecognised level string is silently read as the
 	// message rather than throwing).
-	const hasLevel = Boolean(logFunctions[levelOrMessage]);
+	const hasLevel = Object.prototype.hasOwnProperty.call(logFunctions, levelOrMessage);
 	const level = hasLevel ? levelOrMessage : ERROR;
 	const [message, context, ...restParameters] = hasLevel ? rest : [levelOrMessage, ...rest];
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+const {randomUUID} = require('node:crypto');
 const {DEBUG, INFO, WARN, ERROR} = require('./constants');
 const jsonLogger = require('./jsonLogger');
 const simpleLogger = require('./simpleLogger');
@@ -27,10 +28,35 @@ function logWithLevel(level) {
 	return (...parameters) => (shouldLog ? logger(level, ...parameters, fetchContext) : noLog);
 }
 
-module.exports = {
+const logFunctions = {
 	[DEBUG]: logWithLevel(DEBUG),
 	[INFO]: logWithLevel(INFO),
 	[WARN]: logWithLevel(WARN),
 	[ERROR]: logWithLevel(ERROR),
+};
+
+function slackAlert(levelOrMessage, ...rest) {
+	// `level` is optional and defaults to "error". If the first argument isn't a known level,
+	// treat it as `message` instead (so an unrecognised level string is silently read as the
+	// message rather than throwing).
+	const hasLevel = Boolean(logFunctions[levelOrMessage]);
+	const level = hasLevel ? levelOrMessage : ERROR;
+	const [message, context, ...restParameters] = hasLevel ? rest : [levelOrMessage, ...rest];
+
+	// An Error passed as `context` (the `logger.error(message, errorObject)` shorthand) must stay
+	// an Error so the underlying logger can still extract its message/stack/statusCode.
+	const isContextAnError = context instanceof Error;
+	const contextWithSlackAlertId = {
+		...(isContextAnError ? undefined : context),
+		slackAlertId: randomUUID(),
+	};
+	const parameters = isContextAnError ? [context, ...restParameters] : restParameters;
+
+	return logFunctions[level](`slackAlert ${message}`, contextWithSlackAlertId, ...parameters);
+}
+
+module.exports = {
+	...logFunctions,
+	slackAlert,
 	addContext,
 };

--- a/test/jsonLogger.spec.js
+++ b/test/jsonLogger.spec.js
@@ -1,6 +1,8 @@
 const assert = require('assert');
 const sinon = require('sinon');
 
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 describe('JSON logger', () => {
 	const write = process.stdout.write;
 	const TAG = '12345';
@@ -63,6 +65,115 @@ describe('JSON logger', () => {
 			error: originalErrorMessage,
 			statusCode: 404,
 			stacktrace: sinon.match.array,
+		});
+	});
+
+	['debug', 'info', 'warn', 'error'].forEach(level => {
+		it(`supports slackAlert at the "${level}" level, prepending "slackAlert " to the message and adding a slackAlertId`, () => {
+			const testMessage = 'something happened';
+
+			logger.slackAlert(level, testMessage);
+
+			sinon.assert.match(JSON.parse(output.trim()), {
+				level,
+				message: `slackAlert ${testMessage}`,
+				tag: TAG,
+				timestamp: now.toISOString(),
+				slackAlertId: sinon.match(UUID_REGEX),
+			});
+		});
+	});
+
+	it('merges the slackAlertId into a provided context object', () => {
+		const testMessage = 'something happened';
+		const context = {id: 1, host: 'example.com'};
+
+		logger.slackAlert('warn', testMessage, context);
+
+		sinon.assert.match(JSON.parse(output.trim()), {
+			level: 'warn',
+			message: `slackAlert ${testMessage}`,
+			...context,
+			slackAlertId: sinon.match(UUID_REGEX),
+		});
+	});
+
+	it('generates a different slackAlertId for each call', () => {
+		logger.slackAlert('info', 'first');
+		const {slackAlertId: firstId} = JSON.parse(output.trim());
+
+		output = '';
+		logger.slackAlert('info', 'second');
+		const {slackAlertId: secondId} = JSON.parse(output.trim());
+
+		assert.notStrictEqual(firstId, secondId);
+	});
+
+	it('supports slackAlert at the "error" level with a context and an error object', () => {
+		const humanReadableErrorMessage = 'Unknown user';
+		const originalErrorMessage = 'user not found';
+		const error = new Error(originalErrorMessage);
+		error.statusCode = 404;
+		const context = {id: 1, host: 'example.com'};
+
+		logger.slackAlert('error', humanReadableErrorMessage, context, error);
+
+		sinon.assert.match(JSON.parse(output.trim()), {
+			level: 'error',
+			message: `slackAlert ${humanReadableErrorMessage}`,
+			tag: TAG,
+			timestamp: now.toISOString(),
+			...context,
+			error: originalErrorMessage,
+			statusCode: 404,
+			stacktrace: sinon.match.array,
+			slackAlertId: sinon.match(UUID_REGEX),
+		});
+	});
+
+	it('supports slackAlert at the "error" level using the (message, errorObject) shorthand, without losing the error details', () => {
+		const originalErrorMessage = 'user not found';
+		const error = new Error(originalErrorMessage);
+		error.statusCode = 404;
+
+		logger.slackAlert('error', 'Unknown user', error);
+
+		sinon.assert.match(JSON.parse(output.trim()), {
+			level: 'error',
+			message: 'slackAlert Unknown user',
+			tag: TAG,
+			timestamp: now.toISOString(),
+			error: originalErrorMessage,
+			statusCode: 404,
+			stacktrace: sinon.match.array,
+			slackAlertId: sinon.match(UUID_REGEX),
+		});
+	});
+
+	it('defaults to the "error" level when level is omitted', () => {
+		const testMessage = 'something happened';
+		const context = {id: 1, host: 'example.com'};
+
+		logger.slackAlert(testMessage, context);
+
+		sinon.assert.match(JSON.parse(output.trim()), {
+			level: 'error',
+			message: `slackAlert ${testMessage}`,
+			...context,
+			slackAlertId: sinon.match(UUID_REGEX),
+		});
+	});
+
+	it('treats an unrecognised level string as the message, defaulting to "error"', () => {
+		const context = {id: 1, host: 'example.com'};
+
+		logger.slackAlert('not-a-real-level', context);
+
+		sinon.assert.match(JSON.parse(output.trim()), {
+			level: 'error',
+			message: 'slackAlert not-a-real-level',
+			...context,
+			slackAlertId: sinon.match(UUID_REGEX),
 		});
 	});
 

--- a/test/simpleLogger.spec.js
+++ b/test/simpleLogger.spec.js
@@ -3,6 +3,8 @@ const chalk = require('chalk');
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SLACK_ALERT_ID_CAPTURE_REGEX = / \{ slackAlertId: '([0-9a-f-]+)' \}$/i;
+// eslint-disable-next-line no-control-regex
+const ANSI_REGEX = /\x1b\[[0-9;]*m/g;
 
 const slackAlertExpectations = {
 	debug: message => chalk.grey(`debug: ${message}`),
@@ -47,13 +49,13 @@ describe('Simple logger', () => {
 
 			logger.slackAlert(level, testMessage);
 
-			const trimmedOutput = output.trim();
+			const trimmedOutput = output.trim().replace(ANSI_REGEX, '');
 			const [, slackAlertId] = trimmedOutput.match(SLACK_ALERT_ID_CAPTURE_REGEX) || [];
 
 			assert.match(slackAlertId, UUID_REGEX);
 			assert.strictEqual(
 				trimmedOutput.replace(SLACK_ALERT_ID_CAPTURE_REGEX, ''),
-				expected(`slackAlert ${testMessage}`)
+				expected(`slackAlert ${testMessage}`).replace(ANSI_REGEX, '')
 			);
 		});
 	});

--- a/test/simpleLogger.spec.js
+++ b/test/simpleLogger.spec.js
@@ -1,6 +1,16 @@
 const assert = require('assert');
 const chalk = require('chalk');
 
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SLACK_ALERT_ID_CAPTURE_REGEX = / \{ slackAlertId: '([0-9a-f-]+)' \}$/i;
+
+const slackAlertExpectations = {
+	debug: message => chalk.grey(`debug: ${message}`),
+	info: message => `${chalk.green('info:')} ${message}`,
+	warn: message => `${chalk.yellow('warn:')} ${message}`,
+	error: message => `${chalk.red('error:')} ${message}`,
+};
+
 describe('Simple logger', () => {
 	const write = process.stdout.write;
 	let output;
@@ -29,5 +39,22 @@ describe('Simple logger', () => {
 		logger.info(testMessage);
 
 		assert.strictEqual(output.trim(), `${chalk.green('info:')} ${testMessage}`);
+	});
+
+	Object.entries(slackAlertExpectations).forEach(([level, expected]) => {
+		it(`supports slackAlert at the "${level}" level, prepending "slackAlert " to the message and adding a slackAlertId`, () => {
+			const testMessage = 'something happened';
+
+			logger.slackAlert(level, testMessage);
+
+			const trimmedOutput = output.trim();
+			const [, slackAlertId] = trimmedOutput.match(SLACK_ALERT_ID_CAPTURE_REGEX) || [];
+
+			assert.match(slackAlertId, UUID_REGEX);
+			assert.strictEqual(
+				trimmedOutput.replace(SLACK_ALERT_ID_CAPTURE_REGEX, ''),
+				expected(`slackAlert ${testMessage}`)
+			);
+		});
 	});
 });


### PR DESCRIPTION
This pull request adds a new `slackAlert` logging method to the logger, allowing important events to be logged with a unique `slackAlertId` for correlation and alerting (e.g., sending to Slack). The implementation supports all log levels, automatically generates a UUID, and is thoroughly tested for expected behaviors and edge cases.

### Slack alert logging feature

* Added `logger.slackAlert([level], message, ...)` method, which prepends `"slackAlert "` to the message and adds a unique `slackAlertId` (UUID) to the log context. The log level defaults to `'error'` if not provided, and all arguments are forwarded to the appropriate logger. This enables easy integration with log-shipping pipelines for Slack alerting. [[1]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R1) [[2]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L30-R60) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R42-R57)

### Test coverage

* Added comprehensive tests for `slackAlert` in both `jsonLogger` and `simpleLogger`, covering all log levels, context merging, error handling, UUID generation, default behaviors, and handling of unrecognized levels. [[1]](diffhunk://#diff-b1a71686c98221617fe979f8d30775c9c566e4860b8d457df35d23758bc305f6R4-R5) [[2]](diffhunk://#diff-b1a71686c98221617fe979f8d30775c9c566e4860b8d457df35d23758bc305f6R71-R179) [[3]](diffhunk://#diff-5181a6fe45052e1e769e5d0386b4ca39930814f3b722781217d4def18ba66747R4-R13) [[4]](diffhunk://#diff-5181a6fe45052e1e769e5d0386b4ca39930814f3b722781217d4def18ba66747R43-R59)

### Documentation

* Updated `README.md` with usage instructions, examples, and notes for the new `slackAlert` method.